### PR TITLE
add required semicolon

### DIFF
--- a/spec/new-productions.htm
+++ b/spec/new-productions.htm
@@ -5,7 +5,7 @@
 
   <emu-grammar>
     PublicFieldDefinition :
-      PropertyName[?Yield] Initializer?
+      PropertyName[?Yield] Initializer? ;
   </emu-grammar>
 </emu-clause>
 
@@ -42,7 +42,7 @@
   <p>With parameters _isStatic_ and _homeObject_.</p>
 
   <emu-grammar>
-    PublicFieldDefinition : PropertyName[?Yield] Initializer?
+    PublicFieldDefinition : PropertyName[?Yield] Initializer? ;
   </emu-grammar>
   <emu-alg>
     1. Let _fieldName_ be the result of performing PropName of |PropertyName|.


### PR DESCRIPTION
Don't worry, haters; ASI will still insert it for you. This is necessary to make the grammar unambiguous.
