### PR TITLE
Early error for arguments in initializer

### DIFF
--- a/spec/modified-productions.htm
+++ b/spec/modified-productions.htm
@@ -172,3 +172,16 @@
     </emu-alg>
   </emu-clause>
 </emu-clause>
+
+<emu-clause id="sec-performeval">
+  <h1>Runtime Semantics: PerformEval ( _x_, _evalRealm_, _strictCaller_, _direct_ )</h1>
+  <emu-clause id="sec-performeval-rules-in-initializer">
+    <h1>Additional Early Error Rules for Eval Inside |Initializer|</h1>
+    <p>These static semantics are applied by PerformEval when a direct eval call occurs inside a class field initializer.</p>
+    <emu-grammar>ScriptBody : StatementList</emu-grammar>
+    <ul>
+      <li>It is a Syntax Error if |StatementList| Contains an |IdentifierReference| whose StringValue is `"arguments"`.</li>
+      <li>The remaining eval rules apply as <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-constructors">outside a constructor</a>, <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-methods">inside a method</a>, and <a href="https://tc39.github.io/ecma262/#sec-performeval-rules-outside-functions">inside a function</a>.</li>
+    </ul>
+  </emu-clause>
+</emu-clause>

--- a/spec/new-productions.htm
+++ b/spec/new-productions.htm
@@ -7,6 +7,18 @@
     PublicFieldDefinition :
       PropertyName[?Yield] Initializer?
   </emu-grammar>
+
+  <emu-clause id="no-arguments">
+    <h1>Static Semantics: Early Errors</h1>
+
+    <emu-grammar>
+      PublicFieldDefinition :
+        PropertyName[?Yield] Initializer?
+    </emu-grammar>
+    <ul>
+      <li>It is a Syntax Error if |Initializer| Contains an |IdentifierReference| whose StringValue is `"arguments"`.
+    </ul>
+  </emu-clause>
 </emu-clause>
 
 <emu-clause id="static-semantics-class-public-fields">


### PR DESCRIPTION
At the November 2016 TC39 meeting as well as previous meetings,
the committee discussed potential confusion from the value of
`arguments` inside a class field initializer. This PR creates an
early error for such a reference, including inside eval. I had
previously thought that an early error for a case like this would
be unusual and a runtime error would therefore be preferable, but
@adamk pointed out that such an error is analogous to errors for
new.target in the wrong location; the specification here is
analogous as well.