### PR TITLE
remove the stage of this proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,4 @@ Please do not create new issues/PRs on this repo.
 
 This presents two related proposals: "class instance fields" and "class static fields". "Class instance fields" describe properties intended to exist on instances of a class (and may optionally include initializer expressions for said properties). "Class static fields" are declarative properties that exist on the class object itself (and may optionally include initializer expressions for said properties).
 
-This proposal is currently at [Stage 2](https://github.com/tc39/proposals).
-
 Latest spec text: https://tc39.github.io/proposal-class-public-fields/


### PR DESCRIPTION
Should this proposal (that's merged with the proposal-class-fields) still have a stage number?
From my naive point of view  mentioning a certain stage for the proposal (stage 2) which doesn't match the stage of the merged proposal (stage 3) might cause confusion.

I would understand keeping it there for historical reasons though.