### PR TITLE
Add a badge for specifying current stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NOTE: This proposal has been merged with the [Private Fields proposal](https://github.com/tc39/proposal-private-fields) to form a single unified proposal [here](https://github.com/tc39/proposal-class-fields).
 
+![Stage 2](https://badges.aleen42.com/src/tc39_3.svg)
+
 Please do not create new issues/PRs on this repo.
 
 # ES Class Fields & Static Properties


### PR DESCRIPTION
According to https://es.discourse.group/t/a-standard-badge-for-tc39/731, automatically generate a badge for specifying current stage of the proposal.